### PR TITLE
all: add customerId as query parameter to account search

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,10 +33,9 @@ All URIs are relative to *http://localhost:8085*
 
 Class | Method | HTTP request | Description
 ------------ | ------------- | ------------- | -------------
-*AccountsApi* | [**CreateAccount**](docs/AccountsApi.md#createaccount) | **Post** /customers/{customer_id}/accounts | Create a new account for a Customer
+*AccountsApi* | [**CreateAccount**](docs/AccountsApi.md#createaccount) | **Post** /accounts | Create a new account for a Customer
 *AccountsApi* | [**CreateTransaction**](docs/AccountsApi.md#createtransaction) | **Post** /accounts/transactions | Post a transaction against multiple accounts. All transaction lines must sum to zero. No money is created or destroyed in a transaction - only moved from account to account. Accounts can be referred to in a Transaction without creating them first.
 *AccountsApi* | [**GetAccountTransactions**](docs/AccountsApi.md#getaccounttransactions) | **Get** /accounts/{account_id}/transactions | Get transactions for an account. Ordered descending from their posted date.
-*AccountsApi* | [**GetAccountsByCustomerID**](docs/AccountsApi.md#getaccountsbycustomerid) | **Get** /customers/{customer_id}/accounts | Retrieves a list of accounts associated with the customer ID.
 *AccountsApi* | [**Ping**](docs/AccountsApi.md#ping) | **Get** /ping | Ping the Accounts service to check if running
 *AccountsApi* | [**SearchAccounts**](docs/AccountsApi.md#searchaccounts) | **Get** /accounts/search | Search for account which matches all query parameters
 

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -37,7 +37,7 @@ paths:
         explode: true
         in: query
         name: number
-        required: true
+        required: false
         schema:
           example: "2151"
           type: string
@@ -46,7 +46,7 @@ paths:
         explode: true
         in: query
         name: routingNumber
-        required: true
+        required: false
         schema:
           example: "69100013"
           type: string
@@ -55,9 +55,18 @@ paths:
         explode: true
         in: query
         name: type
-        required: true
+        required: false
         schema:
           example: Checking
+          type: string
+        style: form
+      - description: Customer ID associated to accounts
+        explode: true
+        in: query
+        name: customerId
+        required: false
+        schema:
+          example: cb9012eb
           type: string
         style: form
       - description: Optional Request ID allows application developer to trace requests
@@ -191,62 +200,10 @@ paths:
         date.
       tags:
       - Accounts
-  /customers/{customer_id}/accounts:
-    get:
-      operationId: getAccountsByCustomerID
-      parameters:
-      - description: Customer Id
-        explode: false
-        in: path
-        name: customer_id
-        required: true
-        schema:
-          example: e210a9d6-d755-4455-9bd2-9577ea7e1081
-          type: string
-        style: simple
-      - description: Optional Request ID allows application developer to trace requests
-          through the systems logs
-        example: rs4f9915
-        explode: false
-        in: header
-        name: X-Request-Id
-        required: false
-        schema:
-          type: string
-        style: simple
-      - description: Moov User ID header, required in all requests
-        example: e3cdf999
-        explode: false
-        in: header
-        name: X-User-Id
-        required: true
-        schema:
-          type: string
-        style: simple
-      responses:
-        200:
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Accounts'
-          description: An array of account objects for the supplied customer ID
-        404:
-          description: A resource with the specified ID was not found
-      summary: Retrieves a list of accounts associated with the customer ID.
-      tags:
-      - Accounts
+  /accounts:
     post:
       operationId: createAccount
       parameters:
-      - description: Customer Id
-        explode: false
-        in: path
-        name: customer_id
-        required: true
-        schema:
-          example: e210a9d6-d755-4455-9bd2-9577ea7e1081
-          type: string
-        style: simple
       - description: Optional Request ID allows application developer to trace requests
           through the systems logs
         example: rs4f9915
@@ -295,9 +252,14 @@ components:
     CreateAccount:
       example:
         balance: 1000
+        customerId: 0c584689
         name: Super Checking
         type: Checking
       properties:
+        customerId:
+          description: Customer ID associated with accounts
+          example: 0c584689
+          type: string
         balance:
           description: Initial balance of account in USD cents. This amount is to
             be deposited from an account at another Financial Institution or in-person
@@ -317,6 +279,7 @@ components:
           type: string
       required:
       - balance
+      - customerId
       - name
       - type
       type: object

--- a/client/api_accounts.go
+++ b/client/api_accounts.go
@@ -29,7 +29,6 @@ type AccountsApiService service
 /*
 AccountsApiService Create a new account for a Customer
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param customerId Customer Id
  * @param xUserId Moov User ID header, required in all requests
  * @param createAccount
  * @param optional nil or *CreateAccountOpts - Optional Parameters:
@@ -41,7 +40,7 @@ type CreateAccountOpts struct {
 	XRequestId optional.String
 }
 
-func (a *AccountsApiService) CreateAccount(ctx context.Context, customerId string, xUserId string, createAccount CreateAccount, localVarOptionals *CreateAccountOpts) (Account, *http.Response, error) {
+func (a *AccountsApiService) CreateAccount(ctx context.Context, xUserId string, createAccount CreateAccount, localVarOptionals *CreateAccountOpts) (Account, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Post")
 		localVarPostBody     interface{}
@@ -52,8 +51,7 @@ func (a *AccountsApiService) CreateAccount(ctx context.Context, customerId strin
 	)
 
 	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/customers/{customer_id}/accounts"
-	localVarPath = strings.Replace(localVarPath, "{"+"customer_id"+"}", fmt.Sprintf("%v", customerId), -1)
+	localVarPath := a.client.cfg.BasePath + "/accounts"
 
 	localVarHeaderParams := make(map[string]string)
 	localVarQueryParams := url.Values{}
@@ -353,105 +351,6 @@ func (a *AccountsApiService) GetAccountTransactions(ctx context.Context, account
 }
 
 /*
-AccountsApiService Retrieves a list of accounts associated with the customer ID.
- * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param customerId Customer Id
- * @param xUserId Moov User ID header, required in all requests
- * @param optional nil or *GetAccountsByCustomerIDOpts - Optional Parameters:
- * @param "XRequestId" (optional.String) -  Optional Request ID allows application developer to trace requests through the systems logs
-@return []Account
-*/
-
-type GetAccountsByCustomerIDOpts struct {
-	XRequestId optional.String
-}
-
-func (a *AccountsApiService) GetAccountsByCustomerID(ctx context.Context, customerId string, xUserId string, localVarOptionals *GetAccountsByCustomerIDOpts) ([]Account, *http.Response, error) {
-	var (
-		localVarHttpMethod   = strings.ToUpper("Get")
-		localVarPostBody     interface{}
-		localVarFormFileName string
-		localVarFileName     string
-		localVarFileBytes    []byte
-		localVarReturnValue  []Account
-	)
-
-	// create path and map variables
-	localVarPath := a.client.cfg.BasePath + "/customers/{customer_id}/accounts"
-	localVarPath = strings.Replace(localVarPath, "{"+"customer_id"+"}", fmt.Sprintf("%v", customerId), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	// to determine the Content-Type header
-	localVarHttpContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
-	if localVarHttpContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHttpContentType
-	}
-
-	// to determine the Accept header
-	localVarHttpHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
-	if localVarHttpHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
-	}
-	if localVarOptionals != nil && localVarOptionals.XRequestId.IsSet() {
-		localVarHeaderParams["X-Request-Id"] = parameterToString(localVarOptionals.XRequestId.Value(), "")
-	}
-	localVarHeaderParams["X-User-Id"] = parameterToString(xUserId, "")
-	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
-	if err != nil {
-		return localVarReturnValue, nil, err
-	}
-
-	localVarHttpResponse, err := a.client.callAPI(r)
-	if err != nil || localVarHttpResponse == nil {
-		return localVarReturnValue, localVarHttpResponse, err
-	}
-
-	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
-	localVarHttpResponse.Body.Close()
-	if err != nil {
-		return localVarReturnValue, localVarHttpResponse, err
-	}
-
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v []Account
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, localVarHttpResponse, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, localVarHttpResponse, newErr
-		}
-		return localVarReturnValue, localVarHttpResponse, newErr
-	}
-
-	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-	if err != nil {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: err.Error(),
-		}
-		return localVarReturnValue, localVarHttpResponse, newErr
-	}
-
-	return localVarReturnValue, localVarHttpResponse, nil
-}
-
-/*
 AccountsApiService Ping the Accounts service to check if running
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 */
@@ -518,20 +417,25 @@ func (a *AccountsApiService) Ping(ctx context.Context) (*http.Response, error) {
 /*
 AccountsApiService Search for account which matches all query parameters
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
- * @param number Account number
- * @param routingNumber ABA routing number for the Financial Institution
- * @param type_ Account type
  * @param xUserId Moov User ID header, required in all requests
  * @param optional nil or *SearchAccountsOpts - Optional Parameters:
+ * @param "Number" (optional.String) -  Account number
+ * @param "RoutingNumber" (optional.String) -  ABA routing number for the Financial Institution
+ * @param "Type_" (optional.String) -  Account type
+ * @param "CustomerId" (optional.String) -  Customer ID associated to accounts
  * @param "XRequestId" (optional.String) -  Optional Request ID allows application developer to trace requests through the systems logs
 @return Account
 */
 
 type SearchAccountsOpts struct {
-	XRequestId optional.String
+	Number        optional.String
+	RoutingNumber optional.String
+	Type_         optional.String
+	CustomerId    optional.String
+	XRequestId    optional.String
 }
 
-func (a *AccountsApiService) SearchAccounts(ctx context.Context, number string, routingNumber string, type_ string, xUserId string, localVarOptionals *SearchAccountsOpts) (Account, *http.Response, error) {
+func (a *AccountsApiService) SearchAccounts(ctx context.Context, xUserId string, localVarOptionals *SearchAccountsOpts) (Account, *http.Response, error) {
 	var (
 		localVarHttpMethod   = strings.ToUpper("Get")
 		localVarPostBody     interface{}
@@ -548,9 +452,18 @@ func (a *AccountsApiService) SearchAccounts(ctx context.Context, number string, 
 	localVarQueryParams := url.Values{}
 	localVarFormParams := url.Values{}
 
-	localVarQueryParams.Add("number", parameterToString(number, ""))
-	localVarQueryParams.Add("routingNumber", parameterToString(routingNumber, ""))
-	localVarQueryParams.Add("type", parameterToString(type_, ""))
+	if localVarOptionals != nil && localVarOptionals.Number.IsSet() {
+		localVarQueryParams.Add("number", parameterToString(localVarOptionals.Number.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.RoutingNumber.IsSet() {
+		localVarQueryParams.Add("routingNumber", parameterToString(localVarOptionals.RoutingNumber.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.Type_.IsSet() {
+		localVarQueryParams.Add("type", parameterToString(localVarOptionals.Type_.Value(), ""))
+	}
+	if localVarOptionals != nil && localVarOptionals.CustomerId.IsSet() {
+		localVarQueryParams.Add("customerId", parameterToString(localVarOptionals.CustomerId.Value(), ""))
+	}
 	// to determine the Content-Type header
 	localVarHttpContentTypes := []string{}
 

--- a/client/docs/AccountsApi.md
+++ b/client/docs/AccountsApi.md
@@ -4,10 +4,9 @@ All URIs are relative to *http://localhost:8085*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**CreateAccount**](AccountsApi.md#CreateAccount) | **Post** /customers/{customer_id}/accounts | Create a new account for a Customer
+[**CreateAccount**](AccountsApi.md#CreateAccount) | **Post** /accounts | Create a new account for a Customer
 [**CreateTransaction**](AccountsApi.md#CreateTransaction) | **Post** /accounts/transactions | Post a transaction against multiple accounts. All transaction lines must sum to zero. No money is created or destroyed in a transaction - only moved from account to account. Accounts can be referred to in a Transaction without creating them first.
 [**GetAccountTransactions**](AccountsApi.md#GetAccountTransactions) | **Get** /accounts/{account_id}/transactions | Get transactions for an account. Ordered descending from their posted date.
-[**GetAccountsByCustomerID**](AccountsApi.md#GetAccountsByCustomerID) | **Get** /customers/{customer_id}/accounts | Retrieves a list of accounts associated with the customer ID.
 [**Ping**](AccountsApi.md#Ping) | **Get** /ping | Ping the Accounts service to check if running
 [**SearchAccounts**](AccountsApi.md#SearchAccounts) | **Get** /accounts/search | Search for account which matches all query parameters
 
@@ -15,7 +14,7 @@ Method | HTTP request | Description
 
 ## CreateAccount
 
-> Account CreateAccount(ctx, customerId, xUserId, createAccount, optional)
+> Account CreateAccount(ctx, xUserId, createAccount, optional)
 Create a new account for a Customer
 
 ### Required Parameters
@@ -24,7 +23,6 @@ Create a new account for a Customer
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**customerId** | **string**| Customer Id | 
 **xUserId** | **string**| Moov User ID header, required in all requests | 
 **createAccount** | [**CreateAccount**](CreateAccount.md)|  | 
  **optional** | ***CreateAccountOpts** | optional parameters | nil if no parameters
@@ -36,7 +34,6 @@ Optional parameters are passed through a pointer to a CreateAccountOpts struct
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
-
 
 
  **xRequestId** | **optional.String**| Optional Request ID allows application developer to trace requests through the systems logs | 
@@ -148,50 +145,6 @@ No authorization required
 [[Back to README]](../README.md)
 
 
-## GetAccountsByCustomerID
-
-> []Account GetAccountsByCustomerID(ctx, customerId, xUserId, optional)
-Retrieves a list of accounts associated with the customer ID.
-
-### Required Parameters
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**customerId** | **string**| Customer Id | 
-**xUserId** | **string**| Moov User ID header, required in all requests | 
- **optional** | ***GetAccountsByCustomerIDOpts** | optional parameters | nil if no parameters
-
-### Optional Parameters
-
-Optional parameters are passed through a pointer to a GetAccountsByCustomerIDOpts struct
-
-
-Name | Type | Description  | Notes
-------------- | ------------- | ------------- | -------------
-
-
- **xRequestId** | **optional.String**| Optional Request ID allows application developer to trace requests through the systems logs | 
-
-### Return type
-
-[**[]Account**](Account.md)
-
-### Authorization
-
-No authorization required
-
-### HTTP request headers
-
-- **Content-Type**: Not defined
-- **Accept**: application/json
-
-[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
-[[Back to Model list]](../README.md#documentation-for-models)
-[[Back to README]](../README.md)
-
-
 ## Ping
 
 > Ping(ctx, )
@@ -221,7 +174,7 @@ No authorization required
 
 ## SearchAccounts
 
-> Account SearchAccounts(ctx, number, routingNumber, type_, xUserId, optional)
+> Account SearchAccounts(ctx, xUserId, optional)
 Search for account which matches all query parameters
 
 ### Required Parameters
@@ -230,9 +183,6 @@ Search for account which matches all query parameters
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 **ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
-**number** | **string**| Account number | 
-**routingNumber** | **string**| ABA routing number for the Financial Institution | 
-**type_** | **string**| Account type | 
 **xUserId** | **string**| Moov User ID header, required in all requests | 
  **optional** | ***SearchAccountsOpts** | optional parameters | nil if no parameters
 
@@ -244,9 +194,10 @@ Optional parameters are passed through a pointer to a SearchAccountsOpts struct
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
 
-
-
-
+ **number** | **optional.String**| Account number | 
+ **routingNumber** | **optional.String**| ABA routing number for the Financial Institution | 
+ **type_** | **optional.String**| Account type | 
+ **customerId** | **optional.String**| Customer ID associated to accounts | 
  **xRequestId** | **optional.String**| Optional Request ID allows application developer to trace requests through the systems logs | 
 
 ### Return type

--- a/client/docs/CreateAccount.md
+++ b/client/docs/CreateAccount.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**CustomerId** | **string** | Customer ID associated with accounts | 
 **Balance** | **int32** | Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation. | 
 **Name** | **string** | Caller defined label for this account. | 
 **Type** | **string** | Product type of the account | 

--- a/client/model_create_account.go
+++ b/client/model_create_account.go
@@ -10,6 +10,8 @@
 package openapi
 
 type CreateAccount struct {
+	// Customer ID associated with accounts
+	CustomerId string `json:"customerId"`
 	// Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation.
 	Balance int32 `json:"balance"`
 	// Caller defined label for this account.

--- a/cmd/server/account_storage.go
+++ b/cmd/server/account_storage.go
@@ -18,9 +18,10 @@ type accountRepository interface {
 	Close() error
 
 	GetAccounts(accountIds []string) ([]*accounts.Account, error)
-	GetCustomerAccounts(customerId string) ([]*accounts.Account, error)
 	CreateAccount(customerId string, account *accounts.Account) error // TODO(adam): acctType needs strong type, we can drop customerId as it's on accounts.Account
-	SearchAccounts(accountNumber, routingNumber, acctType string) (*accounts.Account, error)
+
+	SearchAccountsByCustomerId(customerId string) ([]*accounts.Account, error)
+	SearchAccountsByRoutingNumber(accountNumber, routingNumber, acctType string) (*accounts.Account, error)
 }
 
 func initAccountStorage(logger log.Logger, name string) (accountRepository, error) {

--- a/cmd/server/account_storage_qledger.go
+++ b/cmd/server/account_storage_qledger.go
@@ -50,23 +50,6 @@ func (r *qledgerAccountRepository) GetAccounts(accountIds []string) ([]*accounts
 	return convertAccounts(accts), nil
 }
 
-func (r *qledgerAccountRepository) GetCustomerAccounts(customerId string) ([]*accounts.Account, error) {
-	query := map[string]interface{}{
-		"query": map[string]interface{}{
-			"must": map[string]interface{}{
-				"terms": []map[string]interface{}{
-					{"customerId": customerId},
-				},
-			},
-		},
-	}
-	accts, err := r.api.SearchAccounts(query)
-	if err != nil {
-		return nil, err
-	}
-	return convertAccounts(accts), nil
-}
-
 func (r *qledgerAccountRepository) CreateAccount(customerId string, account *accounts.Account) error {
 	data := map[string]interface{}{
 		"accountId":        account.Id,
@@ -94,7 +77,7 @@ func (r *qledgerAccountRepository) CreateAccount(customerId string, account *acc
 	})
 }
 
-func (r *qledgerAccountRepository) SearchAccounts(accountNumber, routingNumber, acctType string) (*accounts.Account, error) {
+func (r *qledgerAccountRepository) SearchAccountsByRoutingNumber(accountNumber, routingNumber, acctType string) (*accounts.Account, error) {
 	query := map[string]interface{}{
 		"query": map[string]interface{}{
 			"must": map[string]interface{}{
@@ -116,6 +99,23 @@ func (r *qledgerAccountRepository) SearchAccounts(accountNumber, routingNumber, 
 		return convertAccounts(accts)[0], nil
 	}
 	return nil, nil
+}
+
+func (r *qledgerAccountRepository) SearchAccountsByCustomerId(customerId string) ([]*accounts.Account, error) {
+	query := map[string]interface{}{
+		"query": map[string]interface{}{
+			"must": map[string]interface{}{
+				"terms": []map[string]interface{}{
+					{"customerId": customerId},
+				},
+			},
+		},
+	}
+	accts, err := r.api.SearchAccounts(query)
+	if err != nil {
+		return nil, err
+	}
+	return convertAccounts(accts), nil
 }
 
 func setupQLedgerAccountStorage(endpoint, apiToken string) (*qledgerAccountRepository, error) {

--- a/cmd/server/account_storage_qledger_test.go
+++ b/cmd/server/account_storage_qledger_test.go
@@ -86,7 +86,7 @@ func TestQLedger__Accounts(t *testing.T) {
 	}
 
 	// Now grab accounts for this customer
-	accounts, err := repo.GetCustomerAccounts(customerId)
+	accounts, err := repo.SearchAccountsByCustomerId(customerId)
 	if err != nil {
 		t.Error(err)
 	}
@@ -130,7 +130,7 @@ func TestQLedger__Accounts(t *testing.T) {
 	}
 
 	// Search for account
-	acct, err := repo.SearchAccounts(account.AccountNumber, account.RoutingNumber, "Checking")
+	acct, err := repo.SearchAccountsByRoutingNumber(account.AccountNumber, account.RoutingNumber, "Checking")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/server/account_storage_sqlite_test.go
+++ b/cmd/server/account_storage_sqlite_test.go
@@ -99,7 +99,7 @@ func TestSqliteAccountRepository(t *testing.T) {
 	}
 
 	// and read via another
-	accounts, err = repo.GetCustomerAccounts(account.CustomerId)
+	accounts, err = repo.SearchAccountsByCustomerId(account.CustomerId)
 	if err != nil {
 		t.Error(err)
 	}
@@ -111,7 +111,7 @@ func TestSqliteAccountRepository(t *testing.T) {
 	}
 
 	// finally via a third method
-	acct, err := repo.SearchAccounts(otherAccount.AccountNumber, otherAccount.RoutingNumber, otherAccount.Type)
+	acct, err := repo.SearchAccountsByRoutingNumber(otherAccount.AccountNumber, otherAccount.RoutingNumber, otherAccount.Type)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -120,7 +120,7 @@ func TestSqliteAccountRepository(t *testing.T) {
 	}
 
 	// Change the case of otherAccount.Type
-	acct, err = repo.SearchAccounts(otherAccount.AccountNumber, otherAccount.RoutingNumber, "checKIng")
+	acct, err = repo.SearchAccountsByRoutingNumber(otherAccount.AccountNumber, otherAccount.RoutingNumber, "checKIng")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/server/account_storage_test.go
+++ b/cmd/server/account_storage_test.go
@@ -42,7 +42,7 @@ func (r *testAccountRepository) CreateAccount(customerId string, account *accoun
 	return r.err
 }
 
-func (r *testAccountRepository) SearchAccounts(accountNumber, routingNumber, acctType string) (*accounts.Account, error) {
+func (r *testAccountRepository) SearchAccountsByRoutingNumber(accountNumber, routingNumber, acctType string) (*accounts.Account, error) {
 	if r.err != nil {
 		return nil, r.err
 	}
@@ -50,4 +50,11 @@ func (r *testAccountRepository) SearchAccounts(accountNumber, routingNumber, acc
 		return r.accounts[0], nil
 	}
 	return nil, nil
+}
+
+func (r *testAccountRepository) SearchAccountsByCustomerId(customerId string) ([]*accounts.Account, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.accounts, nil
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,24 +37,27 @@ paths:
         - name: number
           in: query
           description: Account number
-          required: true
           schema:
             type: string
             example: 2151
         - name: routingNumber
           in: query
           description: ABA routing number for the Financial Institution
-          required: true
           schema:
             type: string
             example: "69100013"
         - name: type
           in: query
           description: Account type
-          required: true
           schema:
             type: string
             example: Checking
+        - name: customerId
+          in: query
+          description: Customer ID associated to accounts
+          schema:
+            type: string
+            example: cb9012eb
         - name: X-Request-Id
           in: header
           description: Optional Request ID allows application developer to trace requests through the systems logs
@@ -156,55 +159,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Transactions'
-  /customers/{customer_id}/accounts:
-    get:
-      tags:
-        - Accounts
-      summary: Retrieves a list of accounts associated with the customer ID.
-      operationId: getAccountsByCustomerID
-      parameters:
-        - name: customer_id
-          in: path
-          description: Customer Id
-          required: true
-          schema:
-            type: string
-            example: e210a9d6-d755-4455-9bd2-9577ea7e1081
-        - name: X-Request-Id
-          in: header
-          description: Optional Request ID allows application developer to trace requests through the systems logs
-          example: rs4f9915
-          schema:
-            type: string
-        - name: X-User-Id
-          in: header
-          description: Moov User ID header, required in all requests
-          example: e3cdf999
-          schema:
-            type: string
-          required: true
-      responses:
-        '200':
-          description: An array of account objects for the supplied customer ID
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Accounts'
-        '404':
-          description: A resource with the specified ID was not found
+  /accounts:
     post:
       tags:
         - Accounts
       summary: Create a new account for a Customer
       operationId: createAccount
       parameters:
-        - name: customer_id
-          in: path
-          description: Customer Id
-          required: true
-          schema:
-            type: string
-            example: e210a9d6-d755-4455-9bd2-9577ea7e1081
         - name: X-Request-Id
           in: header
           description: Optional Request ID allows application developer to trace requests through the systems logs
@@ -245,10 +206,15 @@ components:
     CreateAccount:
       type: object
       required:
+        - customerId
         - balance
         - name
         - type
       properties:
+        customerId:
+          type: string
+          description: Customer ID associated with accounts
+          example: 0c584689
         balance:
           type: integer
           description: Initial balance of account in USD cents. This amount is to be deposited from an account at another Financial Institution or in-person (i.e. cash) on account creation.


### PR DESCRIPTION
Due to our load balancer setup we're unable to route /customers/:id/accounts over to our Accounts service (instead of Customers), so for now we're going to add ?customerId=... as part of the account search endpoint. This is annoying.