### PR TITLE
all: support reversing a transaction 

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -37,6 +37,7 @@ Class | Method | HTTP request | Description
 *AccountsApi* | [**CreateTransaction**](docs/AccountsApi.md#createtransaction) | **Post** /accounts/transactions | Post a transaction against multiple accounts. All transaction lines must sum to zero. No money is created or destroyed in a transaction - only moved from account to account. Accounts can be referred to in a Transaction without creating them first.
 *AccountsApi* | [**GetAccountTransactions**](docs/AccountsApi.md#getaccounttransactions) | **Get** /accounts/{account_id}/transactions | Get transactions for an account. Ordered descending from their posted date.
 *AccountsApi* | [**Ping**](docs/AccountsApi.md#ping) | **Get** /ping | Ping the Accounts service to check if running
+*AccountsApi* | [**ReverseTransaction**](docs/AccountsApi.md#reversetransaction) | **Post** /accounts/transactions/{transaction_id}/reversal | Reverse a transaction by debiting the credited and crediting the debited amounts among all accounts involved.
 *AccountsApi* | [**SearchAccounts**](docs/AccountsApi.md#searchaccounts) | **Get** /accounts/search | Search for account which matches all query parameters
 
 

--- a/client/api/openapi.yaml
+++ b/client/api/openapi.yaml
@@ -200,6 +200,55 @@ paths:
         date.
       tags:
       - Accounts
+  /accounts/transactions/{transaction_id}/reversal:
+    post:
+      operationId: reverseTransaction
+      parameters:
+      - description: Transaction ID
+        explode: false
+        in: path
+        name: transaction_id
+        required: true
+        schema:
+          example: 3e2f66e2
+          type: string
+        style: simple
+      - description: Optional Request ID allows application developer to trace requests
+          through the systems logs
+        example: rs4f9915
+        explode: false
+        in: header
+        name: X-Request-Id
+        required: false
+        schema:
+          type: string
+        style: simple
+      - description: Moov User ID header, required in all requests
+        example: e3cdf999
+        explode: false
+        in: header
+        name: X-User-Id
+        required: true
+        schema:
+          type: string
+        style: simple
+      responses:
+        200:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+          description: Transaction reversal success
+        400:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unable to reverse the specified transaction, check error(s).
+      summary: Reverse a transaction by debiting the credited and crediting the debited
+        amounts among all accounts involved.
+      tags:
+      - Accounts
   /accounts:
     post:
       operationId: createAccount

--- a/client/api_accounts.go
+++ b/client/api_accounts.go
@@ -415,6 +415,115 @@ func (a *AccountsApiService) Ping(ctx context.Context) (*http.Response, error) {
 }
 
 /*
+AccountsApiService Reverse a transaction by debiting the credited and crediting the debited amounts among all accounts involved.
+ * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param transactionId Transaction ID
+ * @param xUserId Moov User ID header, required in all requests
+ * @param optional nil or *ReverseTransactionOpts - Optional Parameters:
+ * @param "XRequestId" (optional.String) -  Optional Request ID allows application developer to trace requests through the systems logs
+@return Transaction
+*/
+
+type ReverseTransactionOpts struct {
+	XRequestId optional.String
+}
+
+func (a *AccountsApiService) ReverseTransaction(ctx context.Context, transactionId string, xUserId string, localVarOptionals *ReverseTransactionOpts) (Transaction, *http.Response, error) {
+	var (
+		localVarHttpMethod   = strings.ToUpper("Post")
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+		localVarReturnValue  Transaction
+	)
+
+	// create path and map variables
+	localVarPath := a.client.cfg.BasePath + "/accounts/transactions/{transaction_id}/reversal"
+	localVarPath = strings.Replace(localVarPath, "{"+"transaction_id"+"}", fmt.Sprintf("%v", transactionId), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+
+	// to determine the Content-Type header
+	localVarHttpContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHttpContentType := selectHeaderContentType(localVarHttpContentTypes)
+	if localVarHttpContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHttpContentType
+	}
+
+	// to determine the Accept header
+	localVarHttpHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHttpHeaderAccept := selectHeaderAccept(localVarHttpHeaderAccepts)
+	if localVarHttpHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHttpHeaderAccept
+	}
+	if localVarOptionals != nil && localVarOptionals.XRequestId.IsSet() {
+		localVarHeaderParams["X-Request-Id"] = parameterToString(localVarOptionals.XRequestId.Value(), "")
+	}
+	localVarHeaderParams["X-User-Id"] = parameterToString(xUserId, "")
+	r, err := a.client.prepareRequest(ctx, localVarPath, localVarHttpMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHttpResponse, err := a.client.callAPI(r)
+	if err != nil || localVarHttpResponse == nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	localVarBody, err := ioutil.ReadAll(localVarHttpResponse.Body)
+	localVarHttpResponse.Body.Close()
+	if err != nil {
+		return localVarReturnValue, localVarHttpResponse, err
+	}
+
+	if localVarHttpResponse.StatusCode >= 300 {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHttpResponse.Status,
+		}
+		if localVarHttpResponse.StatusCode == 200 {
+			var v Transaction
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		if localVarHttpResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHttpResponse, newErr
+			}
+			newErr.model = v
+			return localVarReturnValue, localVarHttpResponse, newErr
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+	if err != nil {
+		newErr := GenericOpenAPIError{
+			body:  localVarBody,
+			error: err.Error(),
+		}
+		return localVarReturnValue, localVarHttpResponse, newErr
+	}
+
+	return localVarReturnValue, localVarHttpResponse, nil
+}
+
+/*
 AccountsApiService Search for account which matches all query parameters
  * @param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param xUserId Moov User ID header, required in all requests

--- a/client/docs/AccountsApi.md
+++ b/client/docs/AccountsApi.md
@@ -8,6 +8,7 @@ Method | HTTP request | Description
 [**CreateTransaction**](AccountsApi.md#CreateTransaction) | **Post** /accounts/transactions | Post a transaction against multiple accounts. All transaction lines must sum to zero. No money is created or destroyed in a transaction - only moved from account to account. Accounts can be referred to in a Transaction without creating them first.
 [**GetAccountTransactions**](AccountsApi.md#GetAccountTransactions) | **Get** /accounts/{account_id}/transactions | Get transactions for an account. Ordered descending from their posted date.
 [**Ping**](AccountsApi.md#Ping) | **Get** /ping | Ping the Accounts service to check if running
+[**ReverseTransaction**](AccountsApi.md#ReverseTransaction) | **Post** /accounts/transactions/{transaction_id}/reversal | Reverse a transaction by debiting the credited and crediting the debited amounts among all accounts involved.
 [**SearchAccounts**](AccountsApi.md#SearchAccounts) | **Get** /accounts/search | Search for account which matches all query parameters
 
 
@@ -166,6 +167,50 @@ No authorization required
 
 - **Content-Type**: Not defined
 - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
+[[Back to Model list]](../README.md#documentation-for-models)
+[[Back to README]](../README.md)
+
+
+## ReverseTransaction
+
+> Transaction ReverseTransaction(ctx, transactionId, xUserId, optional)
+Reverse a transaction by debiting the credited and crediting the debited amounts among all accounts involved.
+
+### Required Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+**ctx** | **context.Context** | context for authentication, logging, cancellation, deadlines, tracing, etc.
+**transactionId** | **string**| Transaction ID | 
+**xUserId** | **string**| Moov User ID header, required in all requests | 
+ **optional** | ***ReverseTransactionOpts** | optional parameters | nil if no parameters
+
+### Optional Parameters
+
+Optional parameters are passed through a pointer to a ReverseTransactionOpts struct
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+
+
+ **xRequestId** | **optional.String**| Optional Request ID allows application developer to trace requests through the systems logs | 
+
+### Return type
+
+[**Transaction**](Transaction.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints)
 [[Back to Model list]](../README.md#documentation-for-models)

--- a/cmd/server/transaction_storage.go
+++ b/cmd/server/transaction_storage.go
@@ -16,7 +16,8 @@ type transactionRepository interface {
 	Close() error
 
 	createTransaction(tx transaction, opts createTransactionOpts) error
-	getAccountTransactions(accountID string) ([]transaction, error) // TODO(adam): limit and/or pagination params
+	getAccountTransactions(accountId string) ([]transaction, error) // TODO(adam): limit and/or pagination params
+	getTransaction(transactionId string) (*transaction, error)
 }
 
 type createTransactionOpts struct {

--- a/cmd/server/transaction_storage_qledger.go
+++ b/cmd/server/transaction_storage_qledger.go
@@ -68,12 +68,23 @@ func (r *qledgerTransactionRepository) getAccountTransactions(accountId string) 
 			},
 		},
 	}
-
 	xfers, err := r.api.SearchTransactions(query)
 	if err != nil {
 		return nil, fmt.Errorf("qledger: getAccountTransactions: %v", err)
 	}
+	return convertQLedgerTransactions(xfers), nil
+}
 
+func (r *qledgerTransactionRepository) getTransaction(transactionId string) (*transaction, error) {
+	tx, err := r.api.GetTransaction(transactionId)
+	if err != nil {
+		return nil, fmt.Errorf("qledger: getTransaction: %v", err)
+	}
+	out := convertQLedgerTransactions([]*mledge.Transaction{tx})[0]
+	return &out, nil
+}
+
+func convertQLedgerTransactions(xfers []*mledge.Transaction) []transaction {
 	var transactions []transaction
 	for i := range xfers {
 		var lines []transactionLine
@@ -101,5 +112,5 @@ func (r *qledgerTransactionRepository) getAccountTransactions(accountId string) 
 			Lines:     lines,
 		})
 	}
-	return transactions, nil
+	return transactions
 }

--- a/cmd/server/transaction_storage_qledger.go
+++ b/cmd/server/transaction_storage_qledger.go
@@ -105,7 +105,14 @@ func convertQLedgerTransactions(xfers []*mledge.Transaction) []transaction {
 			}
 			lines = append(lines, tx)
 		}
-		t, _ := time.Parse(models.LedgerTimestampLayout, xfers[i].Timestamp)
+		t, err := time.Parse(models.LedgerTimestampLayout, xfers[i].Timestamp)
+		if err != nil {
+			// Try another format that seems to show up in QLedger reads
+			t, _ = time.Parse("2006-01-02T15:04:05.000Z", xfers[i].Timestamp)
+		}
+		if t.IsZero() {
+			continue // really invalid format
+		}
 		transactions = append(transactions, transaction{
 			ID:        xfers[i].ID,
 			Timestamp: t,

--- a/cmd/server/transaction_storage_qledger_test.go
+++ b/cmd/server/transaction_storage_qledger_test.go
@@ -125,6 +125,15 @@ func TestQLedgerTransactions(t *testing.T) {
 		}
 	}
 
+	// Grab our transaction by its ID
+	transaction, err := transactionRepo.getTransaction(tx.ID)
+	if err != nil || transaction == nil {
+		t.Fatalf("transaction=%v error=%v", transaction, err)
+	}
+	if err := transaction.validate(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Only cleanup if every test was successful, otherwise keep the containers around for debugging
 	transactionRepo.close()
 }

--- a/cmd/server/transaction_storage_qledger_test.go
+++ b/cmd/server/transaction_storage_qledger_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/moov-io/base"
+	mledge "github.com/moov-io/qledger-sdk-go"
 )
 
 type testQLedgerTransactionRepository struct {
@@ -136,4 +137,38 @@ func TestQLedgerTransactions(t *testing.T) {
 
 	// Only cleanup if every test was successful, otherwise keep the containers around for debugging
 	transactionRepo.close()
+}
+
+func TestQLedger__convertQLedgerTransactions(t *testing.T) {
+	a1, a2 := base.ID(), base.ID()
+	incoming := []*mledge.Transaction{
+		{
+			ID: "19defa381fa7125212a430b6e441f04c48618281",
+			Data: map[string]interface{}{
+				"accountIds": []interface{}{a1, a2},
+			},
+			Timestamp: "2019-05-21T16:55:53.933Z",
+			Lines: []*mledge.TransactionLine{
+				{AccountID: a1, Delta: 1000},
+				{AccountID: a2, Delta: -1000},
+			},
+		},
+	}
+	out := convertQLedgerTransactions(incoming)
+	if len(out) != 1 {
+		t.Errorf("got %d transactions", len(out))
+	}
+
+	// Check the reversal fields
+	if out[0].ID != incoming[0].ID {
+		t.Errorf("got %s", out[0].ID)
+	}
+	for i := range out[0].Lines {
+		if out[0].Lines[i].AccountId == a1 && out[0].Lines[i].Amount != 1000 {
+			t.Errorf("a1: unexpected amount %d", out[0].Lines[i].Amount)
+		}
+		if out[0].Lines[i].AccountId == a2 && out[0].Lines[i].Amount != -1000 {
+			t.Errorf("a2: unexpected amount %d", out[0].Lines[i].Amount)
+		}
+	}
 }

--- a/cmd/server/transaction_storage_sqlite_test.go
+++ b/cmd/server/transaction_storage_sqlite_test.go
@@ -99,6 +99,15 @@ func TestSqliteTransactionRepository(t *testing.T) {
 	if err != nil || bal != 500 {
 		t.Errorf("got balance of %d", bal)
 	}
+
+	// Grab our transaction by its ID
+	transaction, err := repo.getTransaction(tx.ID)
+	if err != nil || transaction == nil {
+		t.Fatalf("transaction=%v error=%v", transaction, err)
+	}
+	if err := transaction.validate(); err != nil {
+		t.Fatal(err)
+	}
 }
 
 // TestSqliteTransactionRepository__Internal will create an internal transfer

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -363,6 +363,15 @@ func TestTransactions__createTransactionReversal(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// verify our response was a transaction
+	var tx transaction
+	if err := json.NewDecoder(w.Body).Decode(&tx); err != nil {
+		t.Fatal(err)
+	}
+	if tx.ID != transactionRepo.created.ID {
+		t.Errorf("transactions don't match")
+	}
+
 	// set an error and ensure we fail
 	transactionRepo.err = errors.New("bad thing")
 

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -25,6 +25,7 @@ type mockTransactionRepository struct {
 	err error
 
 	transactions []transaction
+	created      transaction
 }
 
 func (r *mockTransactionRepository) Ping() error {
@@ -39,6 +40,7 @@ func (r *mockTransactionRepository) createTransaction(tx transaction, opts creat
 	if err := tx.validate(); err != nil && !opts.InitialDeposit {
 		return err
 	}
+	r.created = tx
 	return r.err
 }
 
@@ -47,6 +49,13 @@ func (r *mockTransactionRepository) getAccountTransactions(accountID string) ([]
 		return nil, r.err
 	}
 	return r.transactions, nil
+}
+
+func (r *mockTransactionRepository) getTransaction(transactionId string) (*transaction, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+	return &r.transactions[0], nil
 }
 
 func TestTransactionPurpose(t *testing.T) {
@@ -310,5 +319,47 @@ func TestTransactions_CreateInvalid(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Errorf("got %d", w.Code)
+	}
+}
+
+func TestTransactions__createTransactionReversal(t *testing.T) {
+	accountRepo := &testAccountRepository{}
+	transactionRepo := &mockTransactionRepository{
+		transactions: []transaction{
+			{
+				ID:        base.ID(),
+				Timestamp: time.Now(),
+				Lines: []transactionLine{
+					{
+						AccountId: base.ID(),
+						Purpose:   ACHDebit,
+						Amount:    -1000,
+					},
+					{
+						AccountId: base.ID(),
+						Purpose:   ACHCredit,
+						Amount:    1000,
+					},
+				},
+			},
+		},
+	}
+
+	router := mux.NewRouter()
+	addTransactionRoutes(log.NewNopLogger(), router, accountRepo, transactionRepo)
+
+	req := httptest.NewRequest("POST", fmt.Sprintf("/accounts/transactions/%s/reversal", transactionRepo.transactions[0].ID), nil)
+	req.Header.Set("x-user-id", base.ID())
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusOK {
+		t.Errorf("bogus HTTP status: %d", w.Code)
+	}
+	// Check that our reversed transaction is valid
+	if err := transactionRepo.created.validate(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -159,6 +159,46 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Transactions'
+  /accounts/transactions/{transaction_id}/reversal:
+    post:
+      tags:
+        - Accounts
+      summary: Reverse a transaction by debiting the credited and crediting the debited amounts among all accounts involved.
+      operationId: reverseTransaction
+      parameters:
+        - name: transaction_id
+          in: path
+          description: Transaction ID
+          required: true
+          schema:
+            type: string
+            example: 3e2f66e2
+        - name: X-Request-Id
+          in: header
+          description: Optional Request ID allows application developer to trace requests through the systems logs
+          example: rs4f9915
+          schema:
+            type: string
+        - name: X-User-Id
+          in: header
+          description: Moov User ID header, required in all requests
+          example: e3cdf999
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Transaction reversal success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '400':
+          description: Unable to reverse the specified transaction, check error(s).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /accounts:
     post:
       tags:


### PR DESCRIPTION
This PR adds support for reversing a transaction via an HTTP endpoint and generates the OpenAPI doc for generated clients. 

The endpoint will be used by paygate on returned files if needed. We need to handle the accounting of reversing the entries, but not having the transfer picked up by paygate to be merged into files for the Federal Reserve. 

Issue: https://github.com/moov-io/accounts/issues/38