### PR TITLE
cmd/server: accounts: allow transactions with duplicate accountIds

### DIFF
--- a/cmd/server/sqlite.go
+++ b/cmd/server/sqlite.go
@@ -22,7 +22,7 @@ var (
 
 		// Transaction tables
 		`create table if not exists transactions(transaction_id primart key, timestamp datetime, created_at datetime, deleted_at datetime);`,
-		`create table if not exists transaction_lines(transaction_id, account_id, purpose, amount integer, created_at datetime, deleted_at datetime, unique(transaction_id, account_id));`,
+		`create table if not exists transaction_lines(transaction_id, account_id, purpose, amount integer, created_at datetime, deleted_at datetime);`,
 	}
 )
 

--- a/cmd/server/transaction_storage_sqlite_test.go
+++ b/cmd/server/transaction_storage_sqlite_test.go
@@ -299,31 +299,3 @@ func TestTransactions__isInternalDebit(t *testing.T) {
 		t.Errorf("default should assume an internal transfer")
 	}
 }
-
-// TestSqliteTransactions_unique ensures we can't insert a transaction with multiple lines for the same accountId
-func TestSqliteTransactions_unique(t *testing.T) {
-	repo := createTestSqliteTransactionRepository(t)
-	defer repo.Close()
-
-	account1, account2 := base.ID(), base.ID()
-	lines := []transactionLine{
-		// Valid transaction, but has multiple lines for the same accountId
-		{AccountId: account1, Purpose: ACHDebit, Amount: -500},
-		{AccountId: account1, Purpose: ACHDebit, Amount: -100},
-		{AccountId: account2, Purpose: ACHCredit, Amount: 600},
-	}
-	tx := transaction{
-		ID:        base.ID(),
-		Timestamp: time.Now(),
-		Lines:     lines,
-	}
-
-	// Attempt our (invalid) transaction
-	if err := repo.createTransaction(tx, createTransactionOpts{AllowOverdraft: true}); err == nil {
-		t.Fatal("expected error")
-	} else {
-		if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
-			t.Errorf("unknown error: %v", err)
-		}
-	}
-}

--- a/cmd/server/transactions_test.go
+++ b/cmd/server/transactions_test.go
@@ -149,6 +149,23 @@ func TestTransaction__validate(t *testing.T) {
 
 }
 
+func TestTransactions__microDeposits(t *testing.T) {
+	// build two credits and one debit in a transaction
+	accountId := base.ID()
+	tx := transaction{
+		ID:        base.ID(),
+		Timestamp: time.Now(),
+		Lines: []transactionLine{
+			{AccountId: accountId, Purpose: ACHCredit, Amount: 100},
+			{AccountId: accountId, Purpose: ACHCredit, Amount: 200},
+			{AccountId: accountId, Purpose: ACHDebit, Amount: -300},
+		},
+	}
+	if err := tx.validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestTransactions_getAccountId(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/foo", nil)


### PR DESCRIPTION
In short this to allow transactions containing multiple transactionLines
to be posted. The inital usecase is for balanced micro-deposits that
don't impact the account's balance.

Issue: https://github.com/moov-io/paygate/issues/141