### PR TITLE
build: download tools used in CI rather than compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,30 @@ matrix:
         directories:
           - "/Users/travis/Library/Caches/go-build" # GOCACHE
 before_install:
-  - go get -u github.com/client9/misspell/cmd/misspell
+  # Setup directory for binaries
+  - mkdir ./bin
+  - export PATH=$PATH:$PWD/bin
+  # Misspell
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -O misspell.tar.gz https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_linux_64bit.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget -O misspell.tar.gz https://github.com/client9/misspell/releases/download/v0.3.4/misspell_0.3.4_mac_64bit.tar.gz; fi
+  - tar xf misspell.tar.gz && cp ./misspell ./bin/misspell
+  # staticcheck
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2019.2.2/staticcheck_linux_amd64.tar.gz; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget -O staticcheck.tar.gz https://github.com/dominikh/go-tools/releases/download/2019.2.2/staticcheck_darwin_amd64.tar.gz; fi
+  - tar xf staticcheck.tar.gz && cp ./staticcheck/staticcheck ./bin/staticcheck
+  # golint
   - go get -u golang.org/x/lint/golint
-  - go get github.com/fzipp/gocyclo
-  - go get -u honnef.co/go/tools/cmd/staticcheck
-  - go get golang.org/x/tools/cmd/cover
+  # gocyclo
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then wget -O ./bin/gocyclo https://github.com/adamdecaf/gocyclo/releases/download/2019-08-09/gocyclo-linux-amd64; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then wget -O ./bin/gocyclo https://github.com/adamdecaf/gocyclo/releases/download/2019-08-09/gocyclo-darwin-amd64; fi
+  - chmod +x ./bin/gocyclo
+  # mingw (gnu libraries)
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install -y mingw; export PATH=/c/tools/mingw64/bin:"$PATH";fi
+
 before_script:
   - GOFILES=$(find . -type f -name '*.go' | grep -v vendor | grep -v client)
+  - go mod graph
+
 script:
   # Just check gofmt on linux, it's the fastest builder
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then test -z $(gofmt -s -l $GOFILES); fi
@@ -36,16 +53,16 @@ script:
   - gocyclo -over 31 $GOFILES
   - golint -set_exit_status $GOFILES
   - staticcheck ./cmd/*/*.go *.go
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - make
   - make client
   - make docker
+
 before_deploy:
 - make dist
-after_deploy:
-  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-  - make release-push
+
 deploy:
   provider: releases
   api_key:
@@ -58,3 +75,7 @@ deploy:
     tags: true
     go: 1.12.x
   skip_cleanup: true
+
+after_deploy:
+  - echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+  - make release-push


### PR DESCRIPTION
This should speed up builds and keep the repository go.mod unchanged